### PR TITLE
feat: image and ordering of transactions in category tab

### DIFF
--- a/resources/views/livewire/pages/user/categories/index.blade.php
+++ b/resources/views/livewire/pages/user/categories/index.blade.php
@@ -244,4 +244,6 @@ new class extends Component {
         @livewire('pages.user.containers.details-sidebar', ['lazy' => true])
         @livewire('pages.user.containers.right-sidebar', ['lazy' => true])
     </div>
+
+    <x-image-viewer imageUrl="" />
 </section>

--- a/resources/views/livewire/pages/user/categories/view.blade.php
+++ b/resources/views/livewire/pages/user/categories/view.blade.php
@@ -113,7 +113,7 @@ new #[Layout('layouts.app')] class extends Component {
             <ul class="ml-3 mt-2 space-y-1">
                 <!-- Display uncategorized accounts first, directly without a nested dropdown -->
                 @if (count($currentCategory->transactions) > 0)
-                    @foreach ($currentCategory->transactions as $transaction)
+                    @foreach ($currentCategory->transactions->sortByDesc('created_at') as $transaction)
                         <li class="{{ $transaction->types->name == 'Expense' ? 'text-secondary' : 'text-primary' }} cursor-pointer"
                             @click="$dispatch('showRightSidebar', {operation: 'view', page: 'Transaction', component: 'pages.user.transactions.view', modelId: {{ $transaction->id }}}); rightSidebarOpen = true;">
                             <a


### PR DESCRIPTION
Related Issue: ETS-110, ETS-75, ETS-39

Fix the images not viewable while on category tab and change the ordering of transactions to latest